### PR TITLE
Add a separate data store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,6 +2181,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,6 +2666,7 @@ dependencies = [
  "log",
  "pollster",
  "slab",
+ "strum",
  "tobj",
  "wgpu",
  "winit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,6 +2643,7 @@ dependencies = [
  "image",
  "log",
  "pollster",
+ "slab",
  "tobj",
  "wgpu",
  "winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ glam = { version = "0.30.5", features = ["bytemuck"] }
 image = "0.25.6"
 log = "0.4.27"
 pollster = "0.4.0"
+slab = "0.4.11"
 tobj = "4.0.3"
 wgpu = "26.0.1"
 winit = "0.30.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ image = "0.25.6"
 log = "0.4.27"
 pollster = "0.4.0"
 slab = "0.4.11"
+strum = { version = "0.27.2", features = ["derive"] }
 tobj = "4.0.3"
 wgpu = "26.0.1"
 winit = "0.30.11"

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -9,6 +9,8 @@ pub struct Camera {
     pub fov: f32,
     pub near: f32,
     pub far: f32,
+    yaw: f32,
+    pitch: f32,
     uniform_buffer: wgpu::Buffer,
     pub bind_group: wgpu::BindGroup
 }
@@ -65,8 +67,11 @@ impl Camera {
             fov: 45.0 * std::f32::consts::PI / 180.0,
             near: 0.01,
             far: 100.0,
+            // TODO - read this from constructor
+            yaw: 0.0,
+            pitch: 0.0,
             uniform_buffer,
-            bind_group
+            bind_group,
         };
 
         Object::new(camera.into())

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -75,7 +75,7 @@ impl Camera {
     pub fn update_camera_uniform(&self, gpu: &Gpu, xform: glam::Mat4, ratio: f32) {
         let uniform_data = CameraUniform {
             projection: self.get_projection_matrix(ratio),
-            view: xform,
+            view: xform.inverse(),
             camera_pos: xform.to_scale_rotation_translation().2,
             _padding: Default::default()
         };

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -2,7 +2,7 @@ use glam::{Vec3, Mat4};
 use bytemuck::NoUninit;
 use std::num::NonZero;
 
-use crate::{gpu::Gpu, object::Object};
+use crate::{gpu::Gpu, object::{DataStore, Object}};
 
 #[derive(Clone)]
 pub struct Camera {
@@ -26,7 +26,7 @@ pub struct CameraUniform {
 }
 
 impl Camera {
-    pub fn new(gpu: &Gpu) -> Object {
+    pub fn new(gpu: &Gpu, store: &mut DataStore) -> Object {
         let uniform_buffer = gpu.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Camera uniform buffer"),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
@@ -74,7 +74,7 @@ impl Camera {
             bind_group,
         };
 
-        Object::new(camera.into())
+        Object::new(camera, store)
     }
 
     pub fn update_camera_uniform(&self, gpu: &Gpu, xform: glam::Mat4, ratio: f32) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use winit::{
     event::{DeviceEvent, KeyEvent, Modifiers, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     keyboard::{Key, KeyCode, KeyLocation, ModifiersKeyState, NamedKey, PhysicalKey},
-    window::Window
+    window::{CursorGrabMode, Window}
 };
 
 use crate::{
@@ -52,6 +52,8 @@ impl ApplicationHandler for App {
             .with_resizable(false);
 
         let window = event_loop.create_window(attrs).unwrap();
+        let _ = window.set_cursor_grab(CursorGrabMode::Confined);
+        window.set_cursor_visible(false);
         let gpu = pollster::block_on(Gpu::new(window, size)).unwrap();
 
         let scene = Scene::new(vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::{path::Path, rc::Rc};
 
 use camera::Camera;
 use glam::{Mat4, Vec2, Vec3};
-use object::{Object, ObjectData};
+use object::{DataStore, DataToken, Object};
 use model::Model;
 use physics::UserInput;
 use scene::Scene;
@@ -35,6 +35,7 @@ use crate::{
 
 #[derive(Default)]
 struct App {
+    data_store: DataStore,
     renderer: Option<Renderer>,
     scene: Option<Scene>,
     physics: PhysicsController,
@@ -57,10 +58,10 @@ impl ApplicationHandler for App {
         let gpu = pollster::block_on(Gpu::new(window, size)).unwrap();
 
         let scene = Scene::new(vec![
-            Model::load_obj(&gpu, &Path::new("src/res/models/sus/sus.obj"))
+            Model::load_obj(&gpu, &mut self.data_store, &Path::new("src/res/models/sus/sus.obj"))
                 .unwrap()
                 .with_rotation_x(-2.0 * std::f32::consts::PI / 4.0),
-            Camera::new(&gpu)
+            Camera::new(&gpu, &mut self.data_store)
                 .with_translation(Vec3::new(-2.0, 0.0, 6.0))
         ]);
 
@@ -89,7 +90,7 @@ impl ApplicationHandler for App {
 
                 if let Some(renderer) = &mut self.renderer && let Some(scene) = &mut self.scene {
                     self.physics.update(scene, user_input);
-                    renderer.render(&scene).unwrap();
+                    renderer.render(scene, &mut self.data_store).unwrap();
                 }
             }
             WindowEvent::ModifiersChanged(modifiers) => {

--- a/src/model.rs
+++ b/src/model.rs
@@ -11,8 +11,9 @@ use std::rc::{Rc, Weak};
 use std::cell::{Ref, RefCell};
 
 use crate::camera::Camera;
+use crate::object::DataStore;
 use crate::{
-    data::Vertex, gpu::Gpu, material::{Material, SimpleMaterial}, mesh::Mesh, object::{Object, ObjectData}
+    data::Vertex, gpu::Gpu, material::{Material, SimpleMaterial}, mesh::Mesh, object::{Object, DataToken}
 };
 
 #[repr(C, packed)]
@@ -95,7 +96,7 @@ impl Model {
         }
     }
 
-    pub fn load_obj(gpu: &Gpu, path: &Path) -> Result<Object, LoadError> {
+    pub fn load_obj(gpu: &Gpu, store: &mut DataStore, path: &Path) -> Result<Object, LoadError> {
         let (models, materials) = tobj::load_obj(&path, &tobj::GPU_LOAD_OPTIONS)?;
         let materials = materials.unwrap();
         let mut objs = Vec::<Model>::new();
@@ -159,7 +160,7 @@ impl Model {
 
         let result = Object::empty();
         for model in objs {
-            result.add_child(Object::new(ObjectData::Model(Rc::new(model))));
+            result.add_child(Object::new(model, store));
         }
 
         Ok(result)

--- a/src/object.rs
+++ b/src/object.rs
@@ -18,6 +18,7 @@ use crate::{
     data::Vertex, gpu::Gpu, material::{Material, SimpleMaterial}, mesh::Mesh, model::Model
 };
 
+#[derive(Default)]
 pub struct DataStore {
     models: Slab<Model>,
     cameras: Slab<Camera>
@@ -43,7 +44,7 @@ impl DataStore {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, EnumTryAs)]
 pub enum DataToken {
     Empty,
     Model(usize),

--- a/src/object.rs
+++ b/src/object.rs
@@ -2,7 +2,10 @@ use std::ops::Deref;
 use std::path::Path;
 
 use glam::{Mat4, Vec3, Vec4};
+use slab::Slab;
 use tobj::LoadError;
+
+use strum::EnumTryAs;
 
 use bytemuck::NoUninit;
 use std::num::NonZero;
@@ -15,58 +18,68 @@ use crate::{
     data::Vertex, gpu::Gpu, material::{Material, SimpleMaterial}, mesh::Mesh, model::Model
 };
 
-pub enum ObjectData {
+pub struct DataStore {
+    models: Slab<Model>,
+    cameras: Slab<Camera>
+}
+
+impl DataStore {
+    pub fn add_model(&mut self, model: Model) -> DataToken {
+        let id = self.models.insert(model);
+        DataToken::Model(id)
+    }
+
+    pub fn add_camera(&mut self, camera: Camera) -> DataToken {
+        let id = self.cameras.insert(camera);
+        DataToken::Camera(id)
+    }
+
+    pub fn get_model(&mut self, id: usize) -> Option<&mut Model> {
+        self.models.get_mut(id)
+    }
+
+    pub fn get_camera(&mut self, id: usize) -> Option<&mut Camera> {
+        self.cameras.get_mut(id)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum DataToken {
     Empty,
-    Model(Rc<Model>),
-    Camera(Rc<Camera>)
+    Model(usize),
+    Camera(usize)
 }
 
 struct ObjectInternal {
     xform: Mat4,
-    data: ObjectData,
+    data: DataToken,
     parent: Weak<RefCell<ObjectInternal>>,
     children: Vec<Object>
+}
+
+pub trait IntoData {
+    fn into_data(self, store: &mut DataStore) -> DataToken;
+}
+
+impl IntoData for Camera {
+    fn into_data(self, store: &mut DataStore) -> DataToken {
+        store.add_camera(self)
+    }
+}
+
+impl IntoData for Model {
+    fn into_data(self, store: &mut DataStore) -> DataToken {
+        store.add_model(self)
+    }
 }
 
 #[derive(Clone)]
 pub struct Object(Rc<RefCell<ObjectInternal>>);
 
-// TODO - implement ObjectRef with Weak
-
-impl From<ObjectData> for Object {
-    fn from(data: ObjectData) -> Object {
-        Object::new(data)
-    }
-}
-
-impl From<Camera> for ObjectData {
-    fn from(camera: Camera) -> ObjectData {
-        ObjectData::Camera(Rc::new(camera))
-    }
-}
-
-impl From<Camera> for Object {
-    fn from(camera: Camera) -> Object {
-        Object::new(camera.into())
-    }
-}
-
-impl From<Model> for ObjectData {
-    fn from(model: Model) -> ObjectData {
-        ObjectData::Model(Rc::new(model))
-    }
-}
-
-impl From<Model> for Object {
-    fn from(model: Model) -> Object {
-        Object::new(model.into())
-    }
-}
-
 impl Object {
-    pub fn new(data: ObjectData) -> Self {
+    pub fn new(data: impl IntoData, store: &mut DataStore) -> Self {
         Self(Rc::new(RefCell::new(ObjectInternal {
-            data,
+            data: data.into_data(store),
             xform: Default::default(),
             parent: Weak::new(),
             children: Vec::new()
@@ -74,7 +87,12 @@ impl Object {
     }
 
     pub fn empty() -> Self {
-        Self::new(ObjectData::Empty)
+        Self(Rc::new(RefCell::new(ObjectInternal {
+            data: DataToken::Empty,
+            xform: Default::default(),
+            parent: Weak::new(),
+            children: Vec::new()
+        })))
     }
 
     pub fn with_children(self, children: Vec<Object>) -> Self {
@@ -98,20 +116,12 @@ impl Object {
         self.0.borrow_mut().xform = xform;
     }
 
-    pub fn get(&self) -> impl Deref<Target = ObjectData> + '_ {
-        Ref::map(self.0.borrow(), |borrow| &borrow.data)
+    pub fn get_data(&self) -> DataToken {
+        self.0.borrow().data
     }
 
     pub fn add_child(&self, obj: Object) {
         self.0.borrow_mut().children.push(obj);
-            /*
-            Self(Rc::new(RefCell::new(ObjectInternal{
-                parent: Rc::downgrade(&self.0),
-                data,
-                xform: Mat4::default(),
-                children: Vec::new()
-            }
-        ))));*/
     }
 
     pub fn get_child(&self, idx: usize) -> Option<Self> {
@@ -134,24 +144,26 @@ impl Object {
         objs
     }
 
-    pub fn get_all_models(&self) -> Vec<(Rc<Model>, Mat4)> {
+    pub fn get_all_models(&self) -> Vec<(DataToken, Mat4)> {
         self.get_all()
             .into_iter()
             .filter_map(|(obj, xform)| {
-                match &obj.0.borrow().data {
-                    ObjectData::Model(model) => Some((model.clone(), xform)),
+                let data = obj.0.borrow().data;
+                match data {
+                    DataToken::Model(_) => Some((data, xform)),
                     _ => None
                 }
             })
             .collect()
     }
 
-    pub fn get_all_cameras(&self) -> Vec<(Object, Mat4)> {
+    pub fn get_all_cameras(&self) -> Vec<(DataToken, Mat4)> {
         self.get_all()
             .into_iter()
             .filter_map(|(obj, xform)| {
-                match &obj.0.borrow().data {
-                    ObjectData::Camera(_) => Some((obj.clone(), xform)),
+                let data = obj.0.borrow().data;
+                match data {
+                    DataToken::Camera(_) => Some((data, xform)),
                     _ => None
                 }
             })

--- a/src/object.rs
+++ b/src/object.rs
@@ -81,8 +81,20 @@ impl Object {
         self.0.borrow_mut().children = children;
         self
     }
+
+    pub fn get_parent_xform(&self) -> Mat4 {
+        self.0.borrow()
+            .parent
+            .upgrade()
+            .map(|parent| Object(parent).get_local_xform())
+            .unwrap_or_default()
+    }
+
+    pub fn get_local_xform(&self) -> Mat4 {
+        self.0.borrow().xform
+    }
     
-    pub fn set(&mut self, xform: Mat4) {
+    pub fn set_xform(&mut self, xform: Mat4) {
         self.0.borrow_mut().xform = xform;
     }
 

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -1,6 +1,6 @@
 use glam::{Mat4, Vec3};
 
-use crate::scene::Scene;
+use crate::{object::DataStore, scene::Scene};
 
 #[derive(Default, Copy, Clone)]
 pub struct UserInput {

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -9,7 +9,9 @@ pub struct UserInput {
     pub move_left: bool,
     pub move_right: bool,
     pub move_up: bool,
-    pub move_down: bool
+    pub move_down: bool,
+    pub yaw: f32,
+    pub pitch: f32
 }
 
 impl UserInput {
@@ -46,10 +48,6 @@ impl UserInput {
         
         direction
     }
-
-    pub fn clear(&mut self) {
-        *self = Default::default();
-    }
 }
 
 #[derive(Default)]
@@ -59,6 +57,8 @@ impl PhysicsController {
     pub fn update(&self, scene: &mut Scene, input: UserInput) {
         if let Some(camera) = scene.get_camera_object() {
             camera.translate(input.direction() * 0.1);
+            camera.rotate_y(-input.yaw * 0.0025);
+            camera.rotate_x(-input.pitch * 0.0025);
         }
     }
 }

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -1,4 +1,4 @@
-use glam::Vec3;
+use glam::{Mat4, Vec3};
 
 use crate::scene::Scene;
 
@@ -56,9 +56,15 @@ pub struct PhysicsController;
 impl PhysicsController {
     pub fn update(&self, scene: &mut Scene, input: UserInput) {
         if let Some(camera) = scene.get_camera_object() {
-            camera.translate(input.direction() * 0.1);
-            camera.rotate_y(-input.yaw * 0.0025);
-            camera.rotate_x(-input.pitch * 0.0025);
+            let (_, _, pos) = camera.get_local_xform().to_scale_rotation_translation();
+
+            let xform =
+                Mat4::from_rotation_y(-input.yaw * 0.0025)
+                * Mat4::from_rotation_x(-input.pitch * 0.0025)
+                * Mat4::from_translation(pos)
+                * camera.get_parent_xform();
+
+            camera.set_xform(xform);
         }
     }
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -5,7 +5,7 @@ use tobj::LoadError;
 use std::rc::Rc;
 
 use crate::{
-    camera::Camera, data::Vertex, gpu::Gpu, material::{Material, SimpleMaterial}, mesh::Mesh, object::{Object, ObjectData}, model::Model
+    camera::Camera, data::Vertex, gpu::Gpu, material::{Material, SimpleMaterial}, mesh::Mesh, object::{Object, DataToken}, model::Model
 };
 
 pub struct Scene {
@@ -15,11 +15,12 @@ pub struct Scene {
 
 impl Scene {
     pub fn new(objs: Vec<Object>) -> Self {
+        let camera = objs.iter().find(|obj| match obj.get_data() {
+            DataToken::Camera(_) => true,
+            _ => false
+        }).cloned();
+
         let root = Object::empty().with_children(objs);
-        let camera = root.get_all_cameras()
-            .first()
-            .map(|(camera, _)| camera)
-            .cloned();
         
         Self {
             root,
@@ -31,14 +32,7 @@ impl Scene {
         self.camera = Some(camera);
     }
 
-    pub fn get_camera(&self) -> Option<Rc<Camera>> {
-        self.camera.as_ref().map(|obj| match obj.get().deref() {
-            ObjectData::Camera(camera) => camera.clone(),
-            _ => panic!()
-        })
-    }
-
-    pub fn get_camera_object(&mut self) -> &mut Option<Object> {
-        &mut self.camera
+    pub fn get_camera_object(&mut self) -> Option<&mut Object> {
+        self.camera.as_mut()
     }
 }


### PR DESCRIPTION
Replaces resource refcounting with a separate data store. This simplifies mutable access and reasoning about lifetimes.